### PR TITLE
update to elastic.v5

### DIFF
--- a/cmd/bosun/expr/elastic.go
+++ b/cmd/bosun/expr/elastic.go
@@ -10,7 +10,8 @@ import (
 	"bosun.org/models"
 	"bosun.org/opentsdb"
 	"github.com/MiniProfiler/go/miniprofiler"
-	elastic "gopkg.in/olivere/elastic.v3"
+	elastic "gopkg.in/olivere/elastic.v5"
+	"context"
 )
 
 // This uses a global client since the elastic client handles connections
@@ -243,7 +244,7 @@ func (e ElasticHosts) Query(r *ElasticRequest) (*elastic.SearchResult, error) {
 		return nil, err
 	}
 	s.Index(indicies...)
-	return s.SearchSource(r.Source).Do()
+	return s.SearchSource(r.Source).Do(context.Background())
 }
 
 // ElasticRequest is a container for the information needed to query elasticsearch or a date
@@ -393,7 +394,7 @@ func ESDateHistogram(e *State, T miniprofiler.Timer, indexer ESIndexer, keystrin
 		for _, v := range ts.Buckets {
 			val := processESBucketItem(v, rstat)
 			if val != nil {
-				series[time.Unix(v.Key/1000, 0).UTC()] = *val
+				series[time.Unix(int64(v.Key/1000), 0).UTC()] = *val
 			}
 		}
 		if len(series) == 0 {
@@ -430,7 +431,7 @@ func ESDateHistogram(e *State, T miniprofiler.Timer, indexer ESIndexer, keystrin
 			for _, v := range ts.Buckets {
 				val := processESBucketItem(v, rstat)
 				if val != nil {
-					series[time.Unix(v.Key/1000, 0).UTC()] = *val
+					series[time.Unix(int64(v.Key/1000), 0).UTC()] = *val
 				}
 			}
 			if len(series) == 0 {

--- a/cmd/bosun/expr/expr.go
+++ b/cmd/bosun/expr/expr.go
@@ -20,7 +20,7 @@ import (
 	"github.com/MiniProfiler/go/miniprofiler"
 	"github.com/influxdata/influxdb/client"
 	elasticOld "github.com/olivere/elastic"
-	elastic "gopkg.in/olivere/elastic.v3"
+	elastic "gopkg.in/olivere/elastic.v5"
 )
 
 type State struct {


### PR DESCRIPTION
@johnewing1 @hermanschaaf 

This is the very simple support elastic 5 upgrade.

I've tested all the bosun elastic functions and they all still work as expected against elastic 2, all the deprecations in the v5 client were for functions not being used by bosun.

Bosun has made quite a lot of changes in current master about it's handling of elastic clients so this will make it harder to update in future, thoughts?